### PR TITLE
Fix issues if ekomi is down

### DIFF
--- a/app/code/local/Magmodules/Ekomisnippets/Helper/Data.php
+++ b/app/code/local/Magmodules/Ekomisnippets/Helper/Data.php
@@ -32,9 +32,12 @@ class Magmodules_Ekomisnippets_Helper_Data extends Mage_Core_Helper_Abstract
 
         if ($ekomiApiId && $ekomiApiKey) {
             try {
-                $api = 'http://api.ekomi.de/v2/wsdl';
-                $client = new SoapClient($api, array('exceptions' => 0));
+                $defaultSocketTimeout = ini_get('default_socket_timeout');
+                ini_set('default_socket_timeout', 1);
+                $api = 'https://api.ekomi.de/v2/wsdl';
+                $client = new SoapClient($api, array('exceptions' => true, 'connection_timeout' => 1));
                 $sendSnapshotRequest = $client->getSnapshot($ekomiApiId . '|' . $ekomiApiKey, $ekomiVersion);
+                ini_set('default_socket_timeout', $defaultSocketTimeout);
                 $ret = @unserialize(utf8_decode($sendSnapshotRequest));
                 if ($ret['done']) {
                     $snippets = $ret['info'];


### PR DESCRIPTION
This morning, http://api.ekomi.de/v2/wsdl was not reachable. This pretty much killed a client shop. The related message in `system.log` was:

    2021-10-13T07:48:01+00:00 ERR (3): Warning: SoapClient::SoapClient(): I/O warning : failed to load external entity &quot;http://api.ekomi.de/v2/wsdl&quot;  in /var/www/shop/app/code/local/Magmodules/Ekomisnippets/Helper/Data.php on line 36

This PR fixes / improves multiple things:

1. Make sure that SOAP issues lead to exceptions, which are catched and logged.
2. Make sure there is a low timeout (one second) if the API is not reachable.
3. Use HTTPS.